### PR TITLE
Support names with '-' and whitespace in input dictionaries

### DIFF
--- a/src/bindr/__init__.py
+++ b/src/bindr/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from typing import (
     TypeVar,
     NamedTuple,
@@ -154,12 +155,16 @@ def _coerce_generic_type(  # pylint: disable=inconsistent-return-statements
     assert False, "Generic type must have been handled"
 
 
+_MUNGE_NAMES = re.compile(r"[\s|-]")
+
+
 def bind(cls: Type[C], dct: dict, raise_if_missing_attr: bool = True) -> C:
     """Recursively bind dictionary values to attributes on NamedTuple instances whose
     name matches dictionary keys."""
     field_types = _get_fields(cls)
     final_fields = {}
     for key, val in dct.items():
+        key = re.sub(_MUNGE_NAMES, "_", key)
         field_type = field_types.get(key, None)
         if field_type is None:
             if raise_if_missing_attr:

--- a/tests/test_bindr.py
+++ b/tests/test_bindr.py
@@ -30,8 +30,8 @@ def s3_settings_dict():
 @pytest.fixture
 def config_dict(s3_settings_dict, sms_providers):
     return {
-        "api_key": "abcd",
-        "timeout_ms": 3875,
+        "api-key": "abcd",
+        "timeout ms": 3875,
         "pi": 3.14,
         "support_emails": ["crink@crink.com", "crink@bindr.readthedocs.io"],
         "s3_settings": s3_settings_dict,
@@ -70,8 +70,8 @@ class TestNamedTuple:
     ):
         assert Config(
             config_dict["support_emails"],
-            config_dict["api_key"],
-            config_dict["timeout_ms"],
+            config_dict["api-key"],
+            config_dict["timeout ms"],
             config_dict["pi"],
             [
                 Config.SMSServiceConfig(
@@ -154,8 +154,8 @@ class TestDataClass:
     ):
         assert ConfigDataClass(
             config_dict["support_emails"],
-            config_dict["api_key"],
-            config_dict["timeout_ms"],
+            config_dict["api-key"],
+            config_dict["timeout ms"],
             config_dict["pi"],
             [
                 ConfigDataClass.SMSServiceConfig(


### PR DESCRIPTION
Input dictionary keys containing `-` and whitespace characters are automatically coerced to underscores now.