### PR TITLE
Support optional types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = "http://github.com/chrisrink10/bindr"
 EMAIL = "chrisrink10@gmail.com"
 AUTHOR = "Christopher Rink"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 REQUIRED = []
 
@@ -104,6 +104,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tests/test_bindr.py
+++ b/tests/test_bindr.py
@@ -1,5 +1,5 @@
 import sys
-from typing import NamedTuple, List, Dict
+from typing import NamedTuple, List, Dict, Optional
 
 import pytest
 
@@ -37,6 +37,7 @@ def config_dict(s3_settings_dict, sms_providers):
         "s3_settings": s3_settings_dict,
         "sms_providers": sms_providers,
         "accounts": {"crink": "password", "crink2": "securepw"},
+        "backup_db_hostname": None,
     }
 
 
@@ -62,6 +63,8 @@ class TestNamedTuple:
             sms_providers: List[SMSServiceConfig]
             s3_settings: S3Config
             accounts: Dict[str, str]
+            backup_db_hostname: Optional[str]
+            no_reply_email: str = "no-reply@python.org"
 
         return Config
 
@@ -87,6 +90,7 @@ class TestNamedTuple:
                 s3_settings_dict["max_item_size"],
             ),
             config_dict["accounts"],
+            config_dict["backup_db_hostname"],
         ) == bind(Config, config_dict)
 
     def test_forbid_unspecialized_generic(self):
@@ -146,6 +150,8 @@ class TestDataClass:
             sms_providers: List[SMSServiceConfig]
             s3_settings: S3Config
             accounts: Dict[str, str]
+            backup_db_hostname: Optional[str]
+            no_reply_email: str = "no-reply@python.org"
 
         return Config
 
@@ -171,6 +177,7 @@ class TestDataClass:
                 s3_settings_dict["max_item_size"],
             ),
             config_dict["accounts"],
+            config_dict["backup_db_hostname"],
         ) == bind(ConfigDataClass, config_dict)
 
     def test_forbid_unspecialized_generic(self):

--- a/tests/test_bindr.py
+++ b/tests/test_bindr.py
@@ -39,6 +39,7 @@ def config_dict(s3_settings_dict, sms_providers):
         "accounts": {"crink": "password", "crink2": "securepw"},
         "backup_db_hostname": None,
         "db-region": "us-east-1",
+        "db-credentials": ("admin", "password1"),
     }
 
 
@@ -66,6 +67,7 @@ class TestNamedTuple:
             accounts: Dict[str, str]
             backup_db_hostname: Optional[str]
             db_region: Optional[str]
+            db_credentials: tuple
             no_reply_email: str = "no-reply@python.org"
 
         return Config
@@ -94,6 +96,7 @@ class TestNamedTuple:
             config_dict["accounts"],
             config_dict["backup_db_hostname"],
             config_dict["db-region"],
+            config_dict["db-credentials"],
         ) == bind(Config, config_dict)
 
     def test_forbid_unspecialized_generic(self):
@@ -155,6 +158,7 @@ class TestDataClass:
             accounts: Dict[str, str]
             backup_db_hostname: Optional[str]
             db_region: Optional[str]
+            db_credentials: tuple
             no_reply_email: str = "no-reply@python.org"
 
         return Config
@@ -183,6 +187,7 @@ class TestDataClass:
             config_dict["accounts"],
             config_dict["backup_db_hostname"],
             config_dict["db-region"],
+            config_dict["db-credentials"],
         ) == bind(ConfigDataClass, config_dict)
 
     def test_forbid_unspecialized_generic(self):

--- a/tests/test_bindr.py
+++ b/tests/test_bindr.py
@@ -38,6 +38,7 @@ def config_dict(s3_settings_dict, sms_providers):
         "sms_providers": sms_providers,
         "accounts": {"crink": "password", "crink2": "securepw"},
         "backup_db_hostname": None,
+        "db-region": "us-east-1",
     }
 
 
@@ -64,6 +65,7 @@ class TestNamedTuple:
             s3_settings: S3Config
             accounts: Dict[str, str]
             backup_db_hostname: Optional[str]
+            db_region: Optional[str]
             no_reply_email: str = "no-reply@python.org"
 
         return Config
@@ -91,6 +93,7 @@ class TestNamedTuple:
             ),
             config_dict["accounts"],
             config_dict["backup_db_hostname"],
+            config_dict["db-region"],
         ) == bind(Config, config_dict)
 
     def test_forbid_unspecialized_generic(self):
@@ -151,6 +154,7 @@ class TestDataClass:
             s3_settings: S3Config
             accounts: Dict[str, str]
             backup_db_hostname: Optional[str]
+            db_region: Optional[str]
             no_reply_email: str = "no-reply@python.org"
 
         return Config
@@ -178,6 +182,7 @@ class TestDataClass:
             ),
             config_dict["accounts"],
             config_dict["backup_db_hostname"],
+            config_dict["db-region"],
         ) == bind(ConfigDataClass, config_dict)
 
     def test_forbid_unspecialized_generic(self):


### PR DESCRIPTION
Support `Optional[blah]` types on named tuples and dataclasses. 